### PR TITLE
Move JSON serialization to `from_native` method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # [Changelog](https://github.com/yola/drf-madprops)
 
+## 0.1.3
+* Move JSON serialization to `from_native` method
+
 ## 0.1.2
 * Support JSON properties
 

--- a/madprops/__init__.py
+++ b/madprops/__init__.py
@@ -1,3 +1,3 @@
 __doc__ = "DRF library to operate resource's properties as a dictionary"
-__version__ = '0.1.2'
+__version__ = '0.1.3'
 __url__ = 'https://github.com/yola/drf-madprops'

--- a/tests/test_serializers.py
+++ b/tests/test_serializers.py
@@ -46,6 +46,19 @@ class FromNative(SerializerTestCase):
         self.assertEqual(self.preference, TestPreference('k1', 'v1', 4))
 
 
+class FromNativeForJsonProperty(SerializerTestCase):
+    def setUp(self):
+        data = {'json1': [1, 2]}
+        context = {'view': Mock(kwargs={'user_id': 4})}
+        serializer = TestSerializer(context=context)
+        self.patch_from_native()
+        self.preference = serializer.from_native(data)
+
+    def test_converts_value_to_json(self):
+        self.assertEqual(
+            self.preference, TestPreference('json1', json.dumps([1, 2]), 4))
+
+
 class Data(SerializerTestCase):
     def setUp(self):
         serializer = TestSerializer(
@@ -153,14 +166,3 @@ class SaveObject(SerializerTestCase):
             user='user', name='a')
         TestPreference.objects.filter().update.assert_called_once_with(
             value='b')
-
-
-class SaveObjectForJsonProps(SerializerTestCase):
-    def setUp(self):
-        self.pref = TestPreference('json1', [1, 2], 'user')
-        TestSerializer().save_object(self.pref)
-        self.addCleanup(TestPreference.objects.reset_mock)
-
-    def test_dumps_json_props(self):
-        TestPreference.objects.filter().update.assert_called_once_with(
-            value=json.dumps([1, 2]))


### PR DESCRIPTION
Because save_object (where it was before) isn't called in case of nested serializer.