### PR TITLE
Fix update for empty queryset

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # [Changelog](https://github.com/yola/drf-madprops)
 
+## 0.1.4
+* Fix update for case self.object is empty queryset
+
 ## 0.1.3
 * Move JSON serialization to `from_native` method
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # [Changelog](https://github.com/yola/drf-madprops)
 
 ## 0.1.4
-* Fix update for case self.object is empty queryset
+* Fix update for the case when self.object is an empty queryset
 
 ## 0.1.3
 * Move JSON serialization to `from_native` method

--- a/madprops/__init__.py
+++ b/madprops/__init__.py
@@ -1,3 +1,3 @@
 __doc__ = "DRF library to operate resource's properties as a dictionary"
-__version__ = '0.1.3'
+__version__ = '0.1.4'
 __url__ = 'https://github.com/yola/drf-madprops'

--- a/madprops/serializers.py
+++ b/madprops/serializers.py
@@ -126,10 +126,7 @@ class PropertySerializer(ModelSerializer):
         if isinstance(self.object, Iterable):
             return self.object
 
-        if self.object is None:
-            return []
-
-        return [self.object]
+        return [] if self.object is None else [self.object]
 
     def save_object(self, obj, **kwargs):
         # Ensure we have only one property with the same name

--- a/madprops/serializers.py
+++ b/madprops/serializers.py
@@ -69,9 +69,6 @@ class PropertySerializer(ModelSerializer):
 
     @cached_property
     def data(self):
-        if self.object is None:
-            return None
-
         return self._to_representation(self.objects)
 
     def _to_representation(self, objects):
@@ -91,19 +88,9 @@ class PropertySerializer(ModelSerializer):
         for prop in self.opts.read_only_props:
             self.init_data.pop(prop, None)
 
-        if self.object:
-            return self._update()
-
-        return self._create()
-
-    def _create(self):
-        self.object = RelationsList(
-            self.from_native({k: v}) for k, v in self.init_data.iteritems()
-        )
-
-    def _update(self):
         result = RelationsList()
         existent_props = dict((obj.name, obj) for obj in self.objects)
+
         # Set object to None, because it's used in other methods and
         # might break them.
         self.object = None
@@ -138,6 +125,10 @@ class PropertySerializer(ModelSerializer):
         # Ensure we always work with iterable
         if isinstance(self.object, Iterable):
             return self.object
+
+        if self.object is None:
+            return []
+
         return [self.object]
 
     def save_object(self, obj, **kwargs):

--- a/tests/test_serializers.py
+++ b/tests/test_serializers.py
@@ -89,7 +89,7 @@ class DataWhenObjectIsNone(SerializerTestCase):
         self.data = serializer.data
 
     def test_returns_None(self):
-        self.assertIsNone(self.data)
+        self.assertEqual(self.data, {})
 
 
 class ErrorsWhenDataIsNotDict(SerializerTestCase):

--- a/tests/test_serializers.py
+++ b/tests/test_serializers.py
@@ -88,7 +88,7 @@ class DataWhenObjectIsNone(SerializerTestCase):
         serializer = TestSerializer(many=True)
         self.data = serializer.data
 
-    def test_returns_None(self):
+    def test_returns_empty_dict(self):
         self.assertEqual(self.data, {})
 
 


### PR DESCRIPTION
Previously it broke, when we tried to update when no properties were found for given parent object.