### PR TITLE
Fix trying to create properties that are none

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # [Changelog](https://github.com/yola/drf-madprops)
 
+## Dev
+* Fix bug when saving properties if no properties were passed to the serializer
+
 ## 0.2.3
 * Introduced NestedPropertySerializer class, which should be used for nested
   properties case.

--- a/madprops/serializers.py
+++ b/madprops/serializers.py
@@ -206,7 +206,8 @@ class PropertiesOwnerSerializer(ModelSerializer):
             validated_data_minus_properties)
 
         # Now save properties separately.
-        self._save_properties(instance, properties_field)
+        if properties_field is not None:
+            self._save_properties(instance, properties_field)
 
         return instance
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 coverage < 4.0.0
 django >= 1.4.11, < 1.7
-djangorestframework > 3.0.0
+djangorestframework > 3.0.0, < 3.3.0
 mock < 2.0.0
 nose < 2.0.0
 python-coveralls < 3.0.0

--- a/tests/test_serializers.py
+++ b/tests/test_serializers.py
@@ -216,3 +216,27 @@ class DeserializePropertiesOwner(TestCase):
 
     def test_owner_is_updated(self):
         self.assertEqual(self.user_save_mock.call_count, 1)
+
+
+class DeserializePropertiesOwnerWhenOptionalPropertiesOmitted(TestCase):
+    @patch.object(PreferenceForWrite, 'objects')
+    @patch.object(PreferenceForWrite, 'save')
+    @patch.object(User, 'save')
+    def setUp(self, user_save_mock, save_mock, manager_mock):
+        self.manager_mock = manager_mock
+        self.user_save_mock = user_save_mock
+
+        self.user = User(name='username', id=1)
+
+        self.serializer = UserSerializerForWrite(self.user, data={
+            'name': 'new_username'},
+            context={'view': Mock(kwargs={'user_id': 1})})
+        self.serializer.is_valid()
+        self.serializer.save()
+
+    def test_data_is_validated_correctly(self):
+        self.assertEqual(self.serializer.validated_data, {
+            'name': 'new_username'})
+
+    def test_no_new_properties_are_created(self):
+        self.assertFalse(self.manager_mock.create.called)


### PR DESCRIPTION
If properties are not passed to the serializer, `self._save_properties(instance, properties_field)` is called with a value of `None` for `properties_field`.
That will cause a `KeyError`.

Also updated requirements.txt because DRF 3.3.0 no longer supports. Django < 1.7
