### PR TITLE
bump version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # [Changelog](https://github.com/yola/drf-madprops)
 
-## Dev
+## 0.2.4
 * Fix bug when saving properties if no properties were passed to the serializer
 
 ## 0.2.3

--- a/madprops/__init__.py
+++ b/madprops/__init__.py
@@ -1,3 +1,3 @@
 __doc__ = "DRF library to operate resource's properties as a dictionary"
-__version__ = '0.2.3'
+__version__ = '0.2.4'
 __url__ = 'https://github.com/yola/drf-madprops'


### PR DESCRIPTION
0.2.4 fixes a bug that was trying to save properties even if no properties were passed to the serializer