### PR TITLE
Add dict validation checks for PropertySerializer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # [Changelog](https://github.com/yola/drf-madprops)
 
+## Development
+* Add validation of serialized data to ensure dict-ness
+
 ## 0.2.4
 * Fix bug when saving properties if no properties were passed to the serializer
 

--- a/madprops/serializers.py
+++ b/madprops/serializers.py
@@ -2,6 +2,8 @@ import json
 
 from django.db.models import ForeignKey
 from django.utils.functional import cached_property
+from django.utils.translation import ugettext as _
+from rest_framework.exceptions import ValidationError
 from rest_framework.serializers import (BaseSerializer, ListSerializer,
                                         ModelSerializer)
 
@@ -52,7 +54,12 @@ class ListToDictSerializer(ListSerializer):
         return result_dict
 
     def to_internal_value(self, data):
-        data_list = [{name: value} for (name, value) in data.items()]
+        try:
+            data_list = [{name: value} for (name, value) in data.items()]
+        except AttributeError:
+            raise ValidationError(
+                _('Properties should be a key value mapping'))
+
         return super(ListToDictSerializer, self).to_internal_value(data_list)
 
     def save(self):

--- a/tests/test_serializers.py
+++ b/tests/test_serializers.py
@@ -5,6 +5,7 @@ from mock import Mock, patch
 
 from madprops.serializers import PropertiesOwnerSerializer, PropertySerializer
 from rest_framework.serializers import ModelSerializer
+from rest_framework.exceptions import ValidationError
 from unittest2 import TestCase
 
 
@@ -240,3 +241,13 @@ class DeserializePropertiesOwnerWhenOptionalPropertiesOmitted(TestCase):
 
     def test_no_new_properties_are_created(self):
         self.assertFalse(self.manager_mock.create.called)
+
+
+class DeserializePropertiesForNonDictData(TestCase):
+    def setUp(self):
+        self.serializer = PreferenceSerializerForWrite(
+            data=['one', 'two', 'three'])
+
+    def test_raises_validation_error(self):
+        with self.assertRaises(ValidationError):
+            self.serializer.is_valid(raise_exception=True)


### PR DESCRIPTION
Re: https://github.com/yola/userservice/issues/718

Does validation during internal value coercion to ensure passed data is dict-like.