### PR TITLE
Drop unittest2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # [Changelog](https://github.com/yola/drf-madprops)
 
+## dev
+* Dropped Python 2.6 support
+
 ## 1.0.0
 * New version compatible with Django < 1.12 and DRF < 3.6.0
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,4 +4,3 @@ djangorestframework == 3.5.3
 mock < 2.0.0
 nose < 2.0.0
 python-coveralls < 3.0.0
-unittest2 < 1.0.0

--- a/tests/test_serializers.py
+++ b/tests/test_serializers.py
@@ -1,4 +1,5 @@
 import json
+from unittest import TestCase
 
 from django.db import models
 from mock import Mock, patch
@@ -6,7 +7,6 @@ from mock import Mock, patch
 from madprops.serializers import PropertiesOwnerSerializer, PropertySerializer
 from rest_framework.serializers import ModelSerializer
 from rest_framework.exceptions import ValidationError
-from unittest2 import TestCase
 
 
 # Fake models and serializers for them. We have separate models for


### PR DESCRIPTION
We don't need to support Python 2.6